### PR TITLE
fix: remove unit test which depends on platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,6 @@ if(BUILD_TESTING)
   # a copyright and license is added to all source files
   set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
-
-  ament_auto_add_gtest(${PROJECT_NAME}_dmabuf_test test/dmabuf_test.cpp)
 endif()
 
 ament_auto_package()


### PR DESCRIPTION
Remove the unit tests which depends on platform device node: /dev/dma_heap/system, but no permission for some platforms, such as CI server.